### PR TITLE
Add user metadata utility

### DIFF
--- a/__tests__/Auth0UserUpdateUtilities.test.js
+++ b/__tests__/Auth0UserUpdateUtilities.test.js
@@ -1,0 +1,147 @@
+const { Auth0UserUpdateUtilities } = require("../src");
+const faker = require("faker");
+
+describe("Auth0UserUpdateUtilities", () => {
+  let user;
+  let auth0;
+  let util;
+
+  beforeEach(() => {
+    user = {
+      user_metadata: {
+        prop: faker.random.word(),
+        namespace: { prop: faker.random.word() },
+      },
+      app_metadata: {
+        prop: faker.random.word(),
+        namespace: { prop: faker.random.word() },
+      },
+    };
+
+    auth0 = {
+      accessToken: faker.random.alphaNumeric(),
+      domain: faker.internet.domainName(),
+    };
+
+    util = new Auth0UserUpdateUtilities(user, auth0);
+    util.userId = faker.random.alphaNumeric(12);
+    util.apiClient = {
+      updateUser: jest.fn(),
+      updateUserMetadata: jest.fn(),
+      updateAppMetadata: jest.fn(),
+    };
+  });
+
+  describe("setUser", () => {
+    it("sets the user prop", () => {
+      const propName = faker.random.alphaNumeric();
+      const propValue = faker.random.alphaNumeric();
+      util.setUser(propName, propValue);
+      expect(util.user[propName]).toEqual(propValue);
+      expect(util.updatedUserData[propName]).toEqual(propValue);
+      expect(user[propName]).toEqual(propValue);
+    });
+  });
+
+  describe("setUserMeta", () => {
+    it("sets metadata without a namespace", () => {
+      const propName = faker.random.alphaNumeric();
+      const propValue = faker.random.alphaNumeric();
+      util.setUserMeta(propName, propValue);
+      expect(util.user.user_metadata[propName]).toEqual(propValue);
+      expect(user.user_metadata[propName]).toEqual(propValue);
+    });
+
+    it("sets metadata with a namespace", () => {
+      util = new Auth0UserUpdateUtilities(user, auth0, "namespace");
+      const propName = faker.random.alphaNumeric();
+      const propValue = faker.random.alphaNumeric();
+      util.setUserMeta(propName, propValue);
+      expect(util.user.user_metadata["namespace"][propName]).toEqual(propValue);
+      expect(user.user_metadata["namespace"][propName]).toEqual(propValue);
+    });
+  });
+
+  describe("setAppMeta", () => {
+    it("sets metadata without a namespace", () => {
+      const propName = faker.random.alphaNumeric();
+      const propValue = faker.random.alphaNumeric();
+      util.setAppMeta(propName, propValue);
+      expect(util.user.app_metadata[propName]).toEqual(propValue);
+      expect(user.app_metadata[propName]).toEqual(propValue);
+    });
+
+    it("sets metadata with a namespace", () => {
+      util = new Auth0UserUpdateUtilities(user, auth0, "namespace");
+      const propName = faker.random.alphaNumeric();
+      const propValue = faker.random.alphaNumeric();
+      util.setAppMeta(propName, propValue);
+      expect(util.user.app_metadata["namespace"][propName]).toEqual(propValue);
+      expect(user.app_metadata["namespace"][propName]).toEqual(propValue);
+    });
+  });
+
+  describe("getUserMeta", () => {
+    it("gets metadata without a namespace", () => {
+      expect(util.getUserMeta("prop")).toEqual(user.user_metadata.prop);
+    });
+
+    it("gets metadata with a namespace", () => {
+      util = new Auth0UserUpdateUtilities(user, auth0, "namespace");
+      expect(util.getUserMeta("prop")).toEqual(
+        user.user_metadata.namespace.prop
+      );
+    });
+
+    it("gets empty metadata", () => {
+      expect(util.getUserMeta(faker.random.alphaNumeric(12))).toBeUndefined();
+    });
+  });
+
+  describe("getAppMeta", () => {
+    it("gets metadata without a namespace", () => {
+      expect(util.getAppMeta("prop")).toEqual(user.app_metadata.prop);
+    });
+
+    it("gets metadata with a namespace", () => {
+      util = new Auth0UserUpdateUtilities(user, auth0, "namespace");
+      expect(util.getAppMeta("prop")).toEqual(user.app_metadata.namespace.prop);
+    });
+
+    it("gets empty metadata", () => {
+      expect(util.getAppMeta(faker.random.alphaNumeric(12))).toBeUndefined();
+    });
+  });
+
+  describe("updateUser", () => {
+    it("calls updateUser with the correct data", () => {
+      util.userId = faker.random.alphaNumeric(12);
+      util.updatedUserData = { nickname: faker.random.word() };
+      util.updateUser();
+      expect(util.apiClient.updateUser).toHaveBeenCalledWith(
+        { id: util.userId },
+        util.updatedUserData
+      );
+    });
+  });
+
+  describe("updateUserMetadata", () => {
+    it("calls updateUserMetadata with the correct data", () => {
+      util.updateUserMetadata();
+      expect(util.apiClient.updateUserMetadata).toHaveBeenCalledWith(
+        { id: util.userId },
+        util.user.user_metadata
+      );
+    });
+  });
+
+  describe("updateAppMetadata", () => {
+    it("calls updateAppMetadata with the correct data", () => {
+      util.updateAppMetadata();
+      expect(util.apiClient.updateAppMetadata).toHaveBeenCalledWith(
+        { id: util.userId },
+        util.user.app_metadata
+      );
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -907,11 +907,66 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha1-BoWzxH6zAG/+0RfN1VFkth+AU48=",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
       "dev": true
+    },
+    "@types/connect": {
+      "version": "3.4.33",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha1-MWEMkB7KVzuHE8MzCrxua59YhUY=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.8",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express/-/express-4.17.8.tgz",
+      "integrity": "sha1-PfQpMpMxfmHGATfSc6LpbNjV8no=",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-jwt": {
+      "version": "0.0.42",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+      "integrity": "sha1-TwTh+t+dGHJZUNwEGAikpK339a4=",
+      "requires": {
+        "@types/express": "*",
+        "@types/express-unless": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.12",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
+      "integrity": "sha1-mkh9p1dCXk8mfn0cVyAiavf4lZE=",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/express-unless": {
+      "version": "0.5.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-unless/-/express-unless-0.5.1.tgz",
+      "integrity": "sha1-T0QLkF5Cu/Uzgrgge8M33F/5/R8=",
+      "requires": {
+        "@types/express": "*"
+      }
     },
     "@types/graceful-fs": {
       "version": "4.1.3",
@@ -947,11 +1002,15 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/mime": {
+      "version": "2.0.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/mime/-/mime-2.0.3.tgz",
+      "integrity": "sha1-yJO3NyHbc2mZQ7/DZTsd63+qSjo="
+    },
     "@types/node": {
       "version": "14.0.27",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/node/-/node-14.0.27.tgz",
-      "integrity": "sha1-oVGHOvWl6FG1GzsGXJ5jOQqeDrE=",
-      "dev": true
+      "integrity": "sha1-oVGHOvWl6FG1GzsGXJ5jOQqeDrE="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -964,6 +1023,25 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha1-M1CYSfjmeeSt0ViVn9sIZEDpVT8=",
       "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.4",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha1-pZ6FHBuhbAUT6hI4MN1jmgoVy2o="
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
+    },
+    "@types/serve-static": {
+      "version": "1.13.5",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/serve-static/-/serve-static-1.13.5.tgz",
+      "integrity": "sha1-PSXZQaGEFdOrCS3vhG4TWgi7z1M=",
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1027,6 +1105,24 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn-walk/-/acorn-walk-6.2.0.tgz",
       "integrity": "sha1-Ejy487hMIXHx9/slJhWxx4prGow=",
       "dev": true
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      },
+      "dependencies": {
+        "es6-promisify": {
+          "version": "5.0.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
+        }
+      }
     },
     "ajv": {
       "version": "6.12.3",
@@ -1148,6 +1244,14 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "ast-types": {
+      "version": "0.14.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ast-types/-/ast-types-0.14.1.tgz",
+      "integrity": "sha1-C0FQQ3cNeiy+SydwJxy9fSyfYbk=",
+      "requires": {
+        "tslib": "^2.0.1"
+      }
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1157,14 +1261,41 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
+    },
+    "auth0": {
+      "version": "2.28.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/auth0/-/auth0-2.28.0.tgz",
+      "integrity": "sha1-UPXnJYwdnhBKAPzipUexx96Fx0Q=",
+      "requires": {
+        "axios": "^0.19.2",
+        "es6-promisify": "^6.1.1",
+        "form-data": "^3.0.0",
+        "jsonwebtoken": "^8.5.1",
+        "jwks-rsa": "^1.8.0",
+        "lru-memoizer": "^2.1.0",
+        "object.assign": "^4.1.0",
+        "rest-facade": "^1.12.0",
+        "retry": "^0.12.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha1-MbfjnIXxNVtxOe4MZHzw3n+DxoI=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1177,6 +1308,14 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha1-4eguTz6Zniz9YbFhKA0WoRH4ZCg=",
       "dev": true
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "babel-jest": {
       "version": "25.5.1",
@@ -1431,6 +1570,11 @@
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
+    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cache-base/-/cache-base-1.0.1.tgz",
@@ -1453,6 +1597,15 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
+    },
+    "camel-case": {
+      "version": "1.2.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/camel-case/-/camel-case-1.2.2.tgz",
+      "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
+      "requires": {
+        "sentence-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
     },
     "camelcase": {
       "version": "5.3.1",
@@ -1527,6 +1680,29 @@
         }
       }
     },
+    "change-case": {
+      "version": "2.3.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/change-case/-/change-case-2.3.1.tgz",
+      "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
+      "requires": {
+        "camel-case": "^1.1.1",
+        "constant-case": "^1.1.0",
+        "dot-case": "^1.1.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "param-case": "^1.1.0",
+        "pascal-case": "^1.1.0",
+        "path-case": "^1.1.0",
+        "sentence-case": "^1.1.1",
+        "snake-case": "^1.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^1.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
+      }
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ci-info/-/ci-info-2.0.0.tgz",
@@ -1595,8 +1771,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -1633,7 +1808,6 @@
       "version": "1.0.8",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1641,14 +1815,22 @@
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
-      "dev": true
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "constant-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/constant-case/-/constant-case-1.1.2.tgz",
+      "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
+      "requires": {
+        "snake-case": "^1.1.0",
+        "upper-case": "^1.1.1"
+      }
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -1667,6 +1849,11 @@
         }
       }
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw="
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -1676,8 +1863,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1722,6 +1908,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "1.2.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+      "integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU="
+    },
     "data-urls": {
       "version": "1.1.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/data-urls/-/data-urls-1.1.0.tgz",
@@ -1737,7 +1928,6 @@
       "version": "4.1.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.1.1.tgz",
       "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1757,14 +1947,21 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha1-RNLqNnm49NT/ujPwPYZfwee/SVU=",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -1807,11 +2004,32 @@
         }
       }
     },
+    "degenerator": {
+      "version": "1.0.4",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/degenerator/-/degenerator-1.0.4.tgz",
+      "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+      "requires": {
+        "ast-types": "0.x.x",
+        "escodegen": "1.x.x",
+        "esprima": "3.x.x"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -1841,6 +2059,14 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "dot-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/dot-case/-/dot-case-1.1.2.tgz",
+      "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
+      "requires": {
+        "sentence-case": "^1.1.2"
       }
     },
     "ecc-jsbn": {
@@ -1894,6 +2120,16 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
+    },
+    "es6-promisify": {
+      "version": "6.1.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/es6-promisify/-/es6-promisify-6.1.1.tgz",
+      "integrity": "sha1-RoN2Ubewa/b/+JPQPyk5NmjQFiE="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1904,7 +2140,6 @@
       "version": "1.14.3",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/escodegen/-/escodegen-1.14.3.tgz",
       "integrity": "sha1-TnuB+6YVgdyXWC7XjKt/Do1j9QM=",
-      "dev": true,
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -1917,7 +2152,6 @@
           "version": "0.3.0",
           "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/levn/-/levn-0.3.0.tgz",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-          "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
             "type-check": "~0.3.2"
@@ -1927,7 +2161,6 @@
           "version": "0.8.3",
           "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/optionator/-/optionator-0.8.3.tgz",
           "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
-          "dev": true,
           "requires": {
             "deep-is": "~0.1.3",
             "fast-levenshtein": "~2.0.6",
@@ -1940,14 +2173,12 @@
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-          "dev": true
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
         "type-check": {
           "version": "0.3.2",
           "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-          "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2"
           }
@@ -2045,8 +2276,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
-      "dev": true
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "esquery": {
       "version": "1.3.1",
@@ -2077,14 +2307,12 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
-      "dev": true
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0="
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
-      "dev": true
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q="
     },
     "exec-sh": {
       "version": "0.3.4",
@@ -2252,8 +2480,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
-      "dev": true
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2368,8 +2595,12 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha1-EkqohYmSYfaK7bQqfAgN6dpgh0M="
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -2388,6 +2619,11 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -2425,6 +2661,29 @@
       "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/for-in/-/for-in-1.0.2.tgz",
@@ -2448,6 +2707,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha1-v2muopcpgmdfAIZTQrmCmG9rjdk="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2469,6 +2733,43 @@
       "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
       "dev": true,
       "optional": true
+    },
+    "ftp": {
+      "version": "0.3.10",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ftp/-/ftp-0.3.10.tgz",
+      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "xregexp": "2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -2501,6 +2802,61 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "get-uri": {
+      "version": "2.0.4",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/get-uri/-/get-uri-2.0.4.tgz",
+      "integrity": "sha1-1JN6uBniGNTLWuGOT1livvFpzGo=",
+      "requires": {
+        "data-uri-to-buffer": "1",
+        "debug": "2",
+        "extend": "~3.0.2",
+        "file-uri-to-path": "1",
+        "ftp": "~0.3.10",
+        "readable-stream": "2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "get-value": {
@@ -2585,6 +2941,11 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg="
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/has-value/-/has-value-1.0.0.tgz",
@@ -2658,6 +3019,42 @@
       "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
       "dev": true
     },
+    "http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
@@ -2667,6 +3064,25 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha1-uMKGQz6HYCMRsByOo0QT2Fakr4E=",
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "human-signals": {
@@ -2679,7 +3095,6 @@
       "version": "0.4.24",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -2729,8 +3144,12 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "dev": true
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -2858,6 +3277,14 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
@@ -2885,6 +3312,14 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-windows/-/is-windows-1.0.2.tgz",
@@ -2904,8 +3339,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -4365,6 +4799,20 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "jwks-rsa": {
+      "version": "1.9.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwks-rsa/-/jwks-rsa-1.9.0.tgz",
+      "integrity": "sha1-76DNVQwTtwOX4nzYdkvVPEWhrZE=",
+      "requires": {
+        "@types/express-jwt": "0.0.42",
+        "axios": "^0.19.2",
+        "debug": "^4.1.0",
+        "jsonwebtoken": "^8.5.1",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.1.2",
+        "ms": "^2.1.2"
+      }
+    },
     "jws": {
       "version": "3.2.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jws/-/jws-3.2.2.tgz",
@@ -4402,6 +4850,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha1-j5KiWzsWxhMSk6DMg0tKg4oqp8I="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -4422,6 +4875,16 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -4473,6 +4936,37 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "requires": {
+        "lower-case": "^1.1.2"
+      }
+    },
+    "lru-cache": {
+      "version": "4.0.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-cache/-/lru-cache-4.0.2.tgz",
+      "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+      "requires": {
+        "pseudomap": "^1.0.1",
+        "yallist": "^2.0.0"
+      }
+    },
+    "lru-memoizer": {
+      "version": "2.1.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-memoizer/-/lru-memoizer-2.1.3.tgz",
+      "integrity": "sha1-oWoUJI6TBlja+9CZivgqdHojAjU=",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "~4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
@@ -4520,6 +5014,11 @@
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/micromatch/-/micromatch-4.0.2.tgz",
@@ -4530,17 +5029,20 @@
         "picomatch": "^2.0.5"
       }
     },
+    "mime": {
+      "version": "2.4.6",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE="
+    },
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I=",
-      "dev": true
+      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -4625,6 +5127,11 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "netmask": {
+      "version": "1.0.6",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/netmask/-/netmask-1.0.6.tgz",
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -4755,6 +5262,11 @@
         }
       }
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/object-visit/-/object-visit-1.0.1.tgz",
@@ -4762,6 +5274,17 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.pick": {
@@ -4841,6 +5364,41 @@
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
+    "pac-proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
+      "integrity": "sha1-EVseWPkldsrC66cYWTynsON94q0=",
+      "requires": {
+        "agent-base": "^4.2.0",
+        "debug": "^4.1.1",
+        "get-uri": "^2.0.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^3.0.0",
+        "pac-resolver": "^3.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "^4.0.1"
+      }
+    },
+    "pac-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pac-resolver/-/pac-resolver-3.0.0.tgz",
+      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
+      "requires": {
+        "co": "^4.6.0",
+        "degenerator": "^1.0.4",
+        "ip": "^1.1.5",
+        "netmask": "^1.0.6",
+        "thunkify": "^2.1.2"
+      }
+    },
+    "param-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/param-case/-/param-case-1.1.2.tgz",
+      "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
+      "requires": {
+        "sentence-case": "^1.1.2"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
@@ -4868,11 +5426,28 @@
       "integrity": "sha1-xZNByXI/QUxFKXVWTHwApo1YrNI=",
       "dev": true
     },
+    "pascal-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pascal-case/-/pascal-case-1.1.2.tgz",
+      "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
+      "requires": {
+        "camel-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "path-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-case/-/path-case-1.1.2.tgz",
+      "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
+      "requires": {
+        "sentence-case": "^1.1.2"
+      }
     },
     "path-exists": {
       "version": "4.0.0",
@@ -4991,6 +5566,11 @@
         }
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/progress/-/progress-2.0.3.tgz",
@@ -5006,6 +5586,46 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
       }
+    },
+    "proxy-agent": {
+      "version": "3.1.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/proxy-agent/-/proxy-agent-3.1.1.tgz",
+      "integrity": "sha1-fgTga/Nq+mJKFUC+JHtHyXC9MBQ=",
+      "requires": {
+        "agent-base": "^4.2.0",
+        "debug": "4",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^3.0.0",
+        "lru-cache": "^5.1.1",
+        "pac-proxy-agent": "^3.0.1",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^4.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0="
+        }
+      }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.8.0",
@@ -5034,6 +5654,17 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/raw-body/-/raw-body-2.4.1.tgz",
+      "integrity": "sha1-MKyC+Yu1rowVLmcUnayNVRU7Fow=",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.3",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -5070,6 +5701,16 @@
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
         "type-fest": "^0.8.1"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "realpath-native": {
@@ -5234,11 +5875,35 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "rest-facade": {
+      "version": "1.13.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/rest-facade/-/rest-facade-1.13.0.tgz",
+      "integrity": "sha1-ziaAubHJDWqTeZx8aJgvukfiUeI=",
+      "requires": {
+        "change-case": "^2.3.0",
+        "deepmerge": "^3.2.0",
+        "lodash.get": "^4.4.2",
+        "superagent": "^5.1.1",
+        "superagent-proxy": "^2.0.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "3.3.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/deepmerge/-/deepmerge-3.3.0.tgz",
+          "integrity": "sha1-08R/1vOpPVF7FEJrBiihewEl9fc="
+        }
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "rimraf": {
       "version": "2.6.3",
@@ -5272,8 +5937,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
-      "dev": true
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "sane": {
       "version": "4.1.0",
@@ -5430,6 +6094,14 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-5.7.1.tgz",
       "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
     },
+    "sentence-case": {
+      "version": "1.1.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/sentence-case/-/sentence-case-1.1.3.tgz",
+      "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -5458,6 +6130,11 @@
           }
         }
       }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -5508,6 +6185,19 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "smart-buffer": {
+      "version": "4.1.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha1-kWBcJdkWUvRmHqacz0XxszHKIbo="
+    },
+    "snake-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/snake-case/-/snake-case-1.1.2.tgz",
+      "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
+      "requires": {
+        "sentence-case": "^1.1.2"
       }
     },
     "snapdragon": {
@@ -5638,11 +6328,46 @@
         }
       }
     },
+    "socks": {
+      "version": "2.3.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha1-ARKfCl1TTSuJdxLtis6rfuZdeOM=",
+      "requires": {
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "4.0.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha1-PImR8xRbJ5nnDhG9X7yLGWMRY4Y=",
+      "requires": {
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-4.2.1.tgz",
+          "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "dev": true
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -5764,6 +6489,11 @@
         }
       }
     },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -5825,6 +6555,14 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -5857,6 +6595,65 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true
+    },
+    "superagent": {
+      "version": "5.3.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent/-/superagent-5.3.1.tgz",
+      "integrity": "sha1-1i8yNNdrgTjBMg6Q+oPcGFDMq/E=",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha1-MbfjnIXxNVtxOe4MZHzw3n+DxoI=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "qs": {
+          "version": "6.9.4",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/qs/-/qs-6.9.4.tgz",
+          "integrity": "sha1-kJCykNH5FyjTwi5UhDykSupatoc="
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg="
+        }
+      }
+    },
+    "superagent-proxy": {
+      "version": "2.0.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent-proxy/-/superagent-proxy-2.0.0.tgz",
+      "integrity": "sha1-n1dRXNZg4unOVcDmvXD5LrB8PuA=",
+      "requires": {
+        "debug": "^3.1.0",
+        "proxy-agent": "3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -5892,6 +6689,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
       }
     },
     "symbol-tree": {
@@ -5944,6 +6750,20 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/throat/-/throat-5.0.0.tgz",
       "integrity": "sha1-xRmSNYA6rRh1SmZ9ZZtecs4Wdks=",
       "dev": true
+    },
+    "thunkify": {
+      "version": "2.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/thunkify/-/thunkify-2.1.2.tgz",
+      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
+    },
+    "title-case": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/title-case/-/title-case-1.1.2.tgz",
+      "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
+      "requires": {
+        "sentence-case": "^1.1.1",
+        "upper-case": "^1.0.3"
+      }
     },
     "tmpl": {
       "version": "1.0.4",
@@ -5998,6 +6818,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
+    },
     "tough-cookie": {
       "version": "3.0.1",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -6017,6 +6842,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "tslib": {
+      "version": "2.0.1",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha1-QQ6w0RPltjVkkO7HSWA3JbAhtD4="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -6075,6 +6905,11 @@
         "set-value": "^2.0.1"
       }
     },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/unset-value/-/unset-value-1.0.0.tgz",
@@ -6115,6 +6950,19 @@
         }
       }
     },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "requires": {
+        "upper-case": "^1.1.1"
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz",
@@ -6135,6 +6983,11 @@
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.4.0",
@@ -6267,8 +7120,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
-      "dev": true
+      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w="
     },
     "wrap-ansi": {
       "version": "6.2.0",
@@ -6376,11 +7228,21 @@
       "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
       "dev": true
     },
+    "xregexp": {
+      "version": "2.0.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/xregexp/-/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
+    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
       "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Utility functions for use within Auth0 Rules",
   "main": "src/index.js",
   "dependencies": {
-    "jsonwebtoken": "^8.5.1"
+    "jsonwebtoken": "^8.5.1",
+    "auth0": "^2.28.0"
   },
   "devDependencies": {
     "eslint": "^7.1",

--- a/src/Auth0UserUpdateUtilities.js
+++ b/src/Auth0UserUpdateUtilities.js
@@ -1,0 +1,93 @@
+const ManagementClient = require("auth0").ManagementClient;
+
+class Auth0UserUpdateUtilities {
+  constructor(user, auth0, namespace) {
+    this.apiClient = new ManagementClient({
+      token: auth0.accessToken,
+      domain: auth0.domain,
+      options: {
+        retry: {
+          enabled: true,
+          maxRetries: 2,
+        },
+      },
+    });
+
+    this.updatedUserData = {};
+    this.userId = user.user_id;
+    this.user = user;
+    this.user.user_metadata = user.user_metadata || {};
+    this.user.app_metadata = user.app_metadata || {};
+
+    this.isNamespaced = namespace && typeof namespace === "string";
+    if (this.isNamespaced) {
+      this.namespace = namespace;
+      this.user.user_metadata[namespace] = user.user_metadata[namespace] || {};
+      this.user.app_metadata[namespace] = user.app_metadata[namespace] || {};
+    }
+  }
+
+  setUser(key, value) {
+    this.user[key] = value;
+    this.updatedUserData[key] = value;
+  }
+
+  setUserMeta(key, value) {
+    if (this.isNamespaced) {
+      this.user.user_metadata[this.namespace][key] = value;
+    } else {
+      this.user.user_metadata[key] = value;
+    }
+  }
+
+  setAppMeta(key, value) {
+    if (this.isNamespaced) {
+      this.user.app_metadata[this.namespace][key] = value;
+    } else {
+      this.user.app_metadata[key] = value;
+    }
+  }
+
+  getUserMeta(key) {
+    return this.isNamespaced
+      ? this.user.user_metadata[this.namespace][key]
+      : this.user.user_metadata[key];
+  }
+
+  getAppMeta(key) {
+    return this.isNamespaced
+      ? this.user.app_metadata[this.namespace][key]
+      : this.user.app_metadata[key];
+  }
+
+  updateUser() {
+    (async () => {
+      await this.apiClient.updateUser(
+        { id: this.userId },
+        this.updatedUserData
+      );
+    })();
+  }
+
+  updateUserMetadata() {
+    (async () => {
+      await this.apiClient.updateUserMetadata(
+        { id: this.userId },
+        this.user.user_metadata
+      );
+    })();
+  }
+
+  updateAppMetadata() {
+    (async () => {
+      await this.apiClient.updateAppMetadata(
+        { id: this.userId },
+        this.user.app_metadata
+      );
+    })();
+  }
+}
+
+module.exports = {
+  Auth0UserUpdateUtilities,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   ...require("./Auth0RedirectRuleUtilities"),
+  ...require("./Auth0UserUpdateUtilities"),
 };


### PR DESCRIPTION
**Waiting on #4, switch branch to master**

Add `Auth0UserUpdateUtilities` to handle user metadata set/get/update. Uses a newer version of the Node SDK to allow for retries (retries twice with 1 second in between). This is better than nothing and will allow us to add custom retry logic (possibly using [p-retry](https://www.npmjs.com/package/p-retry)) in a future version. 
