### PR TITLE
Improve session token

### DIFF
--- a/__tests__/doRedirect.test.js
+++ b/__tests__/doRedirect.test.js
@@ -57,6 +57,17 @@ describe("doRedirect()", () => {
 
     util.doRedirect(redirectUrl, customSessionToken);
 
-    expect(mockContext.redirect.url).toEqual(`${redirectUrl}?session_token=${customSessionToken}`);
+    expect(mockContext.redirect.url).toEqual(
+      `${redirectUrl}?session_token=${customSessionToken}`
+    );
+  });
+
+  it("does not set a session token if false", () => {
+    const redirectUrl = faker.internet.url();
+    const util = new Auth0RedirectRuleUtilities(mockUser, mockContext);
+
+    util.doRedirect(redirectUrl, false);
+
+    expect(mockContext.redirect.url).toEqual(redirectUrl);
   });
 });

--- a/examples/redirectRuleExample.js
+++ b/examples/redirectRuleExample.js
@@ -13,10 +13,21 @@
 function redirectRuleExample(user, context, callback) {
   const { Auth0RedirectRuleUtilities } = require("@auth0/rule-utilities@0.1.0");
 
+  /*
+  Override or set defaults for configuration values
+  const customConfiguration = {
+    ...configuration,
+    ...{
+      SESSION_TOKEN_SECRET: "custom token secret",
+      SESSION_TOKEN_EXPIRES_IN: "in seconds or a string describing a time span",
+    }
+  }
+  */
+
   const ruleUtils = new Auth0RedirectRuleUtilities(
     user,
     context,
-    configuration
+    configuration // or customConfiguration
   );
 
   if (ruleUtils.isRedirectCallback && ruleUtils.queryParams.session_token) {
@@ -43,6 +54,7 @@ function redirectRuleExample(user, context, callback) {
     try {
       // This method automatically creates a session token.
       // To add data to this token, use ruleUtils.createSessionToken and pass as second param below.
+      // To omit the session token, pass false as second param below.
       ruleUtils.doRedirect(configuration.ID_VERIFICATION_URL);
       callback(null, user, context);
     } catch (error) {

--- a/src/Auth0RedirectRuleUtilities.js
+++ b/src/Auth0RedirectRuleUtilities.js
@@ -11,8 +11,11 @@ class Auth0RedirectRuleUtilities {
   constructor(user, context, configuration) {
     this.context = context || {};
     this.user = user || {};
-    this.tokenSecret = configuration && configuration.SESSION_TOKEN_SECRET;
     this.noRedirectProtocols = noRedirectProtocols;
+
+    configuration = configuration || {};
+    this.tokenSecret = configuration.SESSION_TOKEN_SECRET;
+    this.tokenExpiresIn = configuration.SESSION_TOKEN_EXPIRES_IN || "3d";
 
     this.verify = jwt.verify;
     this.sign = jwt.sign;
@@ -96,7 +99,9 @@ class Auth0RedirectRuleUtilities {
       ...additionalClaims,
     };
 
-    return this.sign(sessionToken, this.tokenSecret, { expiresIn: "3d" });
+    return this.sign(sessionToken, this.tokenSecret, {
+      expiresIn: this.tokenExpiresIn,
+    });
   }
 
   /**
@@ -130,10 +135,11 @@ class Auth0RedirectRuleUtilities {
       throw new Error("Cannot redirect");
     }
 
-    const token = sessionToken || this.createSessionToken();
-    this.context.redirect = {
-      url: `${url}?session_token=${token}`,
-    };
+    if (sessionToken !== false) {
+      url += "?session_token=" + sessionToken || this.createSessionToken();
+    }
+
+    this.context.redirect = { url };
   }
 }
 


### PR DESCRIPTION
**Waiting on #4, switch branch to master**

- Add a custom token expiration using `configuration.SESSION_TOKEN_EXPIRES_IN`
- Allow second param on `doRedirect()` to be set to `false` to skip session token setting on the URL