### PR TITLE
Allow skipping session token during redirect and custom exp

### DIFF
--- a/__tests__/doRedirect.test.js
+++ b/__tests__/doRedirect.test.js
@@ -35,15 +35,6 @@ describe("doRedirect()", () => {
     expect(error).toEqual(new Error("Cannot redirect"));
   });
 
-  it("sets the redirect URL in context", () => {
-    const redirectUrl = faker.internet.url();
-    const util = new Auth0RedirectRuleUtilities(mockUser, mockContext);
-
-    util.doRedirect(redirectUrl);
-
-    expect(mockContext.redirect.url).toEqual(redirectUrl);
-  });
-
   it("sets a custom session token", () => {
     const redirectUrl = faker.internet.url();
     const util = new Auth0RedirectRuleUtilities(mockUser, mockContext, {
@@ -64,10 +55,19 @@ describe("doRedirect()", () => {
       SESSION_TOKEN_SECRET: tokenSecret,
     });
 
-    util.doRedirect(redirectUrl, { generateSessionToken: true });
+    util.doRedirect(redirectUrl);
 
     expect(mockContext.redirect.url.split("=")[0]).toEqual(
       `${redirectUrl}?session_token`
     );
+  });
+
+  it("sets a plain redirect URL in context", () => {
+    const redirectUrl = faker.internet.url();
+    const util = new Auth0RedirectRuleUtilities(mockUser, mockContext);
+
+    util.doRedirect(redirectUrl, { generateSessionToken: false });
+
+    expect(mockContext.redirect.url).toEqual(redirectUrl);
   });
 });

--- a/__tests__/doRedirect.test.js
+++ b/__tests__/doRedirect.test.js
@@ -57,6 +57,17 @@ describe("doRedirect()", () => {
 
     util.doRedirect(redirectUrl, customSessionToken);
 
-    expect(mockContext.redirect.url).toEqual(`${redirectUrl}?session_token=${customSessionToken}`);
+    expect(mockContext.redirect.url).toEqual(
+      `${redirectUrl}?session_token=${customSessionToken}`
+    );
+  });
+
+  it("does not set a session token if false", () => {
+    const redirectUrl = faker.internet.url();
+    const util = new Auth0RedirectRuleUtilities(mockUser, mockContext);
+
+    util.doRedirect(redirectUrl, false);
+
+    expect(mockContext.redirect.url).toEqual(redirectUrl);
   });
 });

--- a/__tests__/doRedirect.test.js
+++ b/__tests__/doRedirect.test.js
@@ -37,15 +37,11 @@ describe("doRedirect()", () => {
 
   it("sets the redirect URL in context", () => {
     const redirectUrl = faker.internet.url();
-    const util = new Auth0RedirectRuleUtilities(mockUser, mockContext, {
-      SESSION_TOKEN_SECRET: tokenSecret,
-    });
+    const util = new Auth0RedirectRuleUtilities(mockUser, mockContext);
 
     util.doRedirect(redirectUrl);
 
-    expect(mockContext.redirect.url.split("=")[0]).toEqual(
-      `${redirectUrl}?session_token`
-    );
+    expect(mockContext.redirect.url).toEqual(redirectUrl);
   });
 
   it("sets a custom session token", () => {
@@ -55,19 +51,23 @@ describe("doRedirect()", () => {
     });
     const customSessionToken = faker.random.alphaNumeric(12);
 
-    util.doRedirect(redirectUrl, customSessionToken);
+    util.doRedirect(redirectUrl, { sessionToken: customSessionToken });
 
     expect(mockContext.redirect.url).toEqual(
       `${redirectUrl}?session_token=${customSessionToken}`
     );
   });
 
-  it("does not set a session token if false", () => {
+  it("generates a session token", () => {
     const redirectUrl = faker.internet.url();
-    const util = new Auth0RedirectRuleUtilities(mockUser, mockContext);
+    const util = new Auth0RedirectRuleUtilities(mockUser, mockContext, {
+      SESSION_TOKEN_SECRET: tokenSecret,
+    });
 
-    util.doRedirect(redirectUrl, false);
+    util.doRedirect(redirectUrl, { generateSessionToken: true });
 
-    expect(mockContext.redirect.url).toEqual(redirectUrl);
+    expect(mockContext.redirect.url.split("=")[0]).toEqual(
+      `${redirectUrl}?session_token`
+    );
   });
 });

--- a/examples/redirectRuleExample.js
+++ b/examples/redirectRuleExample.js
@@ -13,10 +13,21 @@
 function redirectRuleExample(user, context, callback) {
   const { Auth0RedirectRuleUtilities } = require("@auth0/rule-utilities@0.1.0");
 
+  /*
+  Override or set defaults for configuration values
+  const customConfiguration = {
+    ...configuration,
+    ...{
+      SESSION_TOKEN_SECRET: "custom token secret",
+      SESSION_TOKEN_EXPIRES_IN: "in seconds or a string describing a time span",
+    }
+  }
+  */
+
   const ruleUtils = new Auth0RedirectRuleUtilities(
     user,
     context,
-    configuration
+    configuration // or customConfiguration
   );
 
   if (ruleUtils.isRedirectCallback && ruleUtils.queryParams.session_token) {
@@ -43,6 +54,7 @@ function redirectRuleExample(user, context, callback) {
     try {
       // This method automatically creates a session token.
       // To add data to this token, use ruleUtils.createSessionToken and pass as second param below.
+      // To omit the session token, pass false as second param below.
       ruleUtils.doRedirect(configuration.ID_VERIFICATION_URL);
       callback(null, user, context);
     } catch (error) {

--- a/src/Auth0RedirectRuleUtilities.js
+++ b/src/Auth0RedirectRuleUtilities.js
@@ -135,7 +135,7 @@ class Auth0RedirectRuleUtilities {
       throw new Error("Cannot redirect");
     }
 
-    const { sessionToken, generateSessionToken } = options || {};
+    const { sessionToken, generateSessionToken = true } = options || {};
 
     let sessionTokenParam;
     if (sessionToken && typeof sessionToken === "string") {

--- a/src/Auth0RedirectRuleUtilities.js
+++ b/src/Auth0RedirectRuleUtilities.js
@@ -11,8 +11,11 @@ class Auth0RedirectRuleUtilities {
   constructor(user, context, configuration) {
     this.context = context || {};
     this.user = user || {};
-    this.tokenSecret = configuration && configuration.SESSION_TOKEN_SECRET;
     this.noRedirectProtocols = noRedirectProtocols;
+
+    configuration = configuration || {};
+    this.tokenSecret = configuration.SESSION_TOKEN_SECRET;
+    this.tokenExpiresIn = configuration.SESSION_TOKEN_EXPIRES_IN || "3d";
 
     this.verify = jwt.verify;
     this.sign = jwt.sign;
@@ -96,7 +99,9 @@ class Auth0RedirectRuleUtilities {
       ...additionalClaims,
     };
 
-    return this.sign(sessionToken, this.tokenSecret, { expiresIn: "3d" });
+    return this.sign(sessionToken, this.tokenSecret, {
+      expiresIn: this.tokenExpiresIn,
+    });
   }
 
   /**
@@ -130,10 +135,11 @@ class Auth0RedirectRuleUtilities {
       throw new Error("Cannot redirect");
     }
 
-    const token = sessionToken || this.createSessionToken();
-    this.context.redirect = {
-      url: `${url}?session_token=${token}`,
-    };
+    if (sessionToken !== false) {
+      url += "?session_token=" + sessionToken || this.createSessionToken();
+    }
+
+    this.context.redirect = { url };
   }
 }
 

--- a/src/Auth0RedirectRuleUtilities.js
+++ b/src/Auth0RedirectRuleUtilities.js
@@ -128,15 +128,24 @@ class Auth0RedirectRuleUtilities {
    * Check if redirect is possible and set the context if so.
    *
    * @param {sting} url - URL to redirect to.
-   * @param {sting} url - Session token to use or omit to create one.
+   * @param {object|undefined} options - Session token to use or omit to create one.
    */
-  doRedirect(url, sessionToken) {
+  doRedirect(url, options = {}) {
     if (!this.canRedirect || !url) {
       throw new Error("Cannot redirect");
     }
 
-    if (sessionToken !== false) {
-      url += "?session_token=" + sessionToken || this.createSessionToken();
+    const { sessionToken, generateSessionToken } = options || {};
+
+    let sessionTokenParam;
+    if (sessionToken && typeof sessionToken === "string") {
+      sessionTokenParam = sessionToken;
+    } else if (generateSessionToken === true) {
+      sessionTokenParam = this.createSessionToken();
+    }
+
+    if (sessionTokenParam) {
+      url += "?session_token=" + sessionTokenParam;
     }
 
     this.context.redirect = { url };


### PR DESCRIPTION
- Add a custom token expiration using `configuration.SESSION_TOKEN_EXPIRES_IN`
- Allow second param on `doRedirect()` to be set to `false` to skip session token setting on the URL